### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+0.8.1
+============
+
+* `utils.iter_invalid_data()` does not throws KeyError when sample value is missing.
+
 0.8.0
 ============
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ inflection>=0.3.1,<0.4.0
 colander>=1.7.0,<1.8.0
 typing-inspect>=0.4.0,<0.5.0
 typing-extensions>=3.7.2,<3.8
-PyYAML>=3.13
+PyYAML>=5.1,<5.2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with (here / 'requirements.txt').open() as f:
 # ----------------------------
 
 setup(name='typeit',
-      version='0.8.0',
+      version='0.8.1',
       description='typeit brings typed data into your project',
       long_description=README,
       classifiers=[

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,7 @@ def test_iter_invalid_data():
 
     class X(NamedTuple):
         items: Sequence[Item]
+        item: Item
 
     mk_x, dict_x = type_constructor(X)
 


### PR DESCRIPTION
* `utils.iter_invalid_data()` does not throws KeyError when sample value is missing